### PR TITLE
Mobile token removal endpoint update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -296,9 +296,13 @@ Entry of mobile token with given `deviceUuid` will be removed. This combination 
     + Parameters
         + deviceUuid: `deviceuuid123456789` (string, required) - Device UUID
 
-+ Response 200
++ Response 204
     Mobile token asociated with given `deviceUuid` was removed.
     + Body
+    
++ Response 404 (application/json; charset=utf-8)
+    Device UUID not found.
+    + Attributes (Errors)
 
 ## Change password [/account/password]
 


### PR DESCRIPTION
Navrhuji, aby request `DELETE /account/mobileToken/{deviceUuid}` vracel `204 No Content`.
Zároveň jsem doplnil `404` response, která v blueprintu chyběla.

Nechybí ještě nějaké jiné error response?