### PR TITLE
Remove nationality from Account upgrade endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1916,7 +1916,6 @@ Financial amount with VAT rate.
     + `FEMALE`
 + dateOfBirth: `1994-02-10` (string, optional) - date of birth in case of non-Czech citizens
 + placeOfBirth: `CZ` (string, optional) - ISO 3166 alpha 2 country code
-+ nationality: `CZ` (string, optional) - ISO 3166 alpha 2 country code
 + consents (array) - List of consents given by customer
 + typeOfHousing (enum, optional) - type of accommodation
     + OWN


### PR DESCRIPTION
Nationality is duplicate fort field CountryIssuedId in IdentityDocument, therefore should be removed.